### PR TITLE
Add $not support to filter queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ the following command:
 await db.protocols.empty()
 ```
 
+### Query filters
+
+The available filters are shown below:
+
+```javascript
+// find by id
+await db.protocols.find(123)
+// same as above:
+await db.protocols.find({ id: 123 })
+// to find all active protocols:
+await db.protocols.find({ active: true }) 
+// to find all not active protocols:
+await db.protocols.find({ active: { $not: true } })
+// same, to find all protocol except id:
+await db.protocols.find({ id: { $not: 123 } })
+```
+
 ### Disconnection
 
 This module exposes the method `db.disconnect()` to close the connection to the

--- a/lib/db-utils.js
+++ b/lib/db-utils.js
@@ -3,18 +3,27 @@ const sqlite3 = require('sqlite3')
 
 const p = (obj, fn) => promisify(obj[fn].bind(obj))
 
-const mapKeys = (obj, fn) => Object.keys(obj).reduce((copy, key) => {
-  copy[fn(key, obj[key])] = obj[key]
-  return copy
-}, {})
+const noop = p => p
+
+const mapObject = (obj, keyMapFn, valMapFn = noop) =>
+  Object.keys(obj).reduce((copy, key) => {
+    copy[keyMapFn(key, obj[key])] = valMapFn(obj[key])
+    return copy
+  }, {})
+
+const isNotValue = (val) => val && val.hasOwnProperty('$not')
+
+const parseValue = (val) => isNotValue(val) ? val.$not : val
 
 const parseFilter = (filter, divider = ' AND ', prefix = '') => {
   const cols = filter ? Object.keys(filter) : []
 
   if (cols.length === 0) return { assignments: '1 = 1', values: {} }
 
-  const assignments = cols.map((c) => `${c} = $${prefix}${c}`).join(divider)
-  const values = mapKeys(filter, (c) => `$${prefix}${c}`)
+  const assignments = cols.map((c) => isNotValue(filter[c])
+    ? `${c} <> $${prefix}${c}`
+    : `${c} = $${prefix}${c}`).join(divider)
+  const values = mapObject(filter, (c) => `$${prefix}${c}`, parseValue)
 
   return { assignments, values }
 }
@@ -33,7 +42,7 @@ exports.all = (db, ...args) => p(db, 'all')(...args)
 
 exports.insertRow = (db, tableName, row) => {
   const cols = Object.keys(row).join(', ')
-  const values = mapKeys(row, (column) => `$${column}`)
+  const values = mapObject(row, (column) => `$${column}`)
   const valuesCols = Object.keys(values).join(', ')
   const query = `INSERT INTO "${tableName}" (${cols}) VALUES (${valuesCols})`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1493,7 +1493,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1514,12 +1515,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1534,17 +1537,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1661,7 +1667,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1673,6 +1680,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1687,6 +1695,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1694,12 +1703,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1718,6 +1729,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1798,7 +1810,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1810,6 +1823,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1895,7 +1909,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1931,6 +1946,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1950,6 +1966,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1993,12 +2010,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@miroculus/anaconda-io-db",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miroculus/anaconda-io-db",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Handle the data that is saved on the local SQLite on the devices",
   "main": "index.js",
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,22 @@ describe('json db', () => {
     equal(document, result, `Invalid response from db.protocols.findOne(${document.id})`)
   }))
 
+  it('find all documents except id', withDb(async (db) => {
+    const document = mockDocument()
+
+    await db.protocols.create(document)
+
+    const docs = [mockDocument(), mockDocument(), mockDocument()]
+
+    for (let doc of docs) {
+      await db.protocols.create(doc)
+    }
+
+    const result = await db.protocols.find({ id: { $not: document.id } })
+
+    equal(docs, result, `Invalid response from db.protocols.find({ id: { $not: ${document.id} } })`)
+  }))
+
   it('return empty when no document is found', withDb(async (db) => {
     const result = await db.protocols.findOne(1)
     equal(null, result, `Document key was not correctly retrieved`)


### PR DESCRIPTION
The current implementation of the query filter is very basic and it only allows for truthy queries.
This PR adds the functionality to allow the user to write:

```javascript
await db.protocols.find({ id: { $not: 123 } })
```